### PR TITLE
Critical: unique ids were not supported by relations

### DIFF
--- a/lib/relations.js
+++ b/lib/relations.js
@@ -54,7 +54,7 @@ exports.getAll = function getAll(objName, name) {
                       value = [];
                     } else {
                       value = value.map(function (val) {
-                        return val.toString();
+                        return parseInt(val.toString(), 10);
                       });
                     }
                     callback.call(self, err, value);


### PR DESCRIPTION
getAll used parseInt.. to ids that were not integers.

The solution is too hard, Nohm should check what kind of cast should do on a per class basis.
