### PR TITLE
Fixed getClient()/setClient() Bug

### DIFF
--- a/lib/nohm.js
+++ b/lib/nohm.js
@@ -143,14 +143,16 @@ Nohm.setPrefix = function (prefix) {
  */
 Nohm.setClient = function (client) {
   Nohm.client = client;
-  connected_client = (require('util').inspect(Nohm).indexOf('stream') != -1) ? true : false;
   //
   // getClient/setClient No connection patch
   // (github.com/runexec) - Monday 3/26/12 2:31 AM JST
   //
+  connected_client = (require('util').inspect(Nohm).indexOf('stream') != -1) ? true : false;
+  
   if(!connected_client) {
 	throw 'setClient() : Invalid Client() or Client() not connected.';
   }
+  // end patch
 };
 
 


### PR DESCRIPTION
https://github.com/runexec/nohm/blob/master/lib/nohm.js#L144

```
Nohm.setClient = function (client) {
    Nohm.client = client;
    //
    // getClient/setClient No connection patch
    // (github.com/runexec) - Monday 3/26/12 2:31 AM JST
    //
    connected_client = (require('util').inspect(Nohm).indexOf('stream') != -1) ? true : false;

    if(!connected_client) {
        throw 'setClient() : Invalid Client() or Client() not connected.';
    }
};
```
