### PR TITLE
fixes the Object.keys error referenced in Issue #61

### DIFF
--- a/lib/retrieve.js
+++ b/lib/retrieve.js
@@ -35,7 +35,7 @@ exports.load = function (id, callback) {
   }
   this.getClient().hgetall(this.getHashKey(id), function (err, values) {
     var p, value,
-        keys = Object.keys(values),
+        keys = values ? Object.keys(values) : null,
         return_props = {};
     if (err) {
       Nohm.logError('loading a hash produced an error: ' + err);


### PR DESCRIPTION
if the id being passed to load() doesn't exist then the values parameter of hgetall() is null.  Calling Object.keys on null throws an error
