### PR TITLE
Ability to access the object's instance when validating

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# Matches multiple files with brace expansion notation
+# Set default charset
+[*]
+charset = utf-8
+# Indentation override for all JS under lib directory
+indent_style = space
+indent_size = 2

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -174,7 +174,7 @@ exports.__validateProperty = function __validateProperty(p) {
         return cb(null, true);
       }
       var called = false;
-      var res = func(value, options, function (result) {
+      var res = func.call(self, value, options, function (result) {
         if (!result) {
           self.errors[p].push(name);
         }

--- a/test/custom_validations.js
+++ b/test/custom_validations.js
@@ -1,3 +1,7 @@
 exports.customValidationFile = function (value, opt, callback) {
   callback(value === 'customValidationFile');
 };
+
+exports.instanceValidation = function (value, opt, callback) {
+  callback(this.p(opt.property) === value);
+};

--- a/test/testArgs.js
+++ b/test/testArgs.js
@@ -3,6 +3,7 @@ exports.noCleanup = false,
 exports.setMeta = false,
 exports.redis_host = '127.0.0.1',
 exports.redis_port = 6379;
+exports.redis_auth = false;
 
 process.argv.forEach(function (val, index) {
   if (val === '--nohm-prefix') {
@@ -17,6 +18,11 @@ process.argv.forEach(function (val, index) {
   if (val === '--redis-port') {
     exports.redis_port = process.argv[index + 1];
   }
+  if (val === '--redis-auth') {
+    exports.redis_auth = process.argv[index + 1];
+  }
 });
 
-exports.redis = require('redis').createClient(exports.redis_port, exports.redis_host);
+exports.redis = require('redis').createClient(exports.redis_port, exports.redis_host, {
+  auth_pass: exports.redis_auth
+});

--- a/test/validationTests.js
+++ b/test/validationTests.js
@@ -213,6 +213,15 @@ var UserMockup = nohm.model('UserMockup', {
           }
         ]
       ]
+    },
+    customDependentValidation: {
+      type: 'string',
+      defaultValue: 'test',
+      validations: [
+        ['instanceValidation', {
+          property: 'name'
+        }]
+      ]
     }
   }
 });
@@ -535,6 +544,14 @@ exports.validation = {
     var tests = testValidateProp(t, 'UserMockup', 'customValidationFileOptional');
 
     tests.push(true, '');
+
+    tests.launch();
+  },
+
+  customDependentValidation: function(t) {
+    var tests = testValidateProp(t, 'UserMockup', 'customDependentValidation');
+
+    tests.push(true, 'test');
 
     tests.launch();
   },


### PR DESCRIPTION
With this request I've also:

- added a `.editorconfig` file to help contributors (like myself) to keep to your coding standards.
- added ability to test on a database that's password protected (using the variable `--redis-auth`)