### PR TITLE
Remove void return type for propertyDiff()

### DIFF
--- a/docs/api/tsOut_model.js.html
+++ b/docs/api/tsOut_model.js.html
@@ -419,7 +419,8 @@ class NohmModel {
     propertyDiff(key) {
         // TODO: determine if returning an array is really the best option
         if (key) {
-            return [this.onePropertyDiff(key)];
+            const diff = this.onePropertyDiff(key);
+            return diff ? [diff] : [];
         }
         else {
             const diffResult = [];

--- a/test/typescript.test.ts
+++ b/test/typescript.test.ts
@@ -391,3 +391,22 @@ test.serial('validation errors', async (t) => {
     }
   }
 });
+
+test.serial(
+  'return type',
+  async (t) => {
+    const testInstance = await nohm.factory<UserMockup>('UserMockup');
+    const diffBeforeUpdate = testInstance.propertyDiff('name');
+
+    // update the property
+    testInstance.property('name','testName');
+    const diffAfterUpdate = testInstance.propertyDiff('name');
+
+    t.deepEqual(diffBeforeUpdate, [], 'return without undefined');
+    t.deepEqual(diffAfterUpdate, [{
+      after: 'testName',
+      before: 'defaultName',
+      key: 'name',
+    }], 'return with difference in property');
+  },
+);

--- a/ts/model.ts
+++ b/ts/model.ts
@@ -538,7 +538,7 @@ abstract class NohmModel<TProps extends IDictionary = IDictionary> {
    */
   public propertyDiff(
     key?: keyof TProps,
-  ): Array<void | IPropertyDiff<keyof TProps>> {
+  ): Array<IPropertyDiff<keyof TProps>> {
     // TODO: determine if returning an array is really the best option
     if (key) {
       const diff = this.onePropertyDiff(key);

--- a/ts/model.ts
+++ b/ts/model.ts
@@ -541,7 +541,8 @@ abstract class NohmModel<TProps extends IDictionary = IDictionary> {
   ): Array<void | IPropertyDiff<keyof TProps>> {
     // TODO: determine if returning an array is really the best option
     if (key) {
-      return [this.onePropertyDiff(key)];
+      const diff = this.onePropertyDiff(key);
+      return diff ? [diff] : [];
     } else {
       const diffResult: Array<IPropertyDiff<keyof TProps>> = [];
       for (const [iterationKey] of this.properties) {


### PR DESCRIPTION
for issue #186
- Add undefined check on `onePropertyDiff` return value, so as to return empty array from propertyDiff. 